### PR TITLE
Line chart overlay information improvements

### DIFF
--- a/charts/src/commonMain/kotlin/com/netguru/multiplatform/charts/OverlayInformation.kt
+++ b/charts/src/commonMain/kotlin/com/netguru/multiplatform/charts/OverlayInformation.kt
@@ -22,6 +22,11 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 
+/**
+ * @param content Composable content of the overlay information element. The Boolean? parameter states
+ * whether the user-selected (touched and held) area is close to the center of X-axis.
+ * The Boolean? parameter is applicable only to line chart.
+ */
 @Composable
 internal fun OverlayInformation(
     positionX: Float?,
@@ -32,7 +37,7 @@ internal fun OverlayInformation(
     requiredOverlayWidth: Dp?,
     overlayAlpha: Float,
     pointsToAvoid: List<Offset> = emptyList(),
-    content: @Composable () -> Unit,
+    content: @Composable (Boolean?) -> Unit,
 ) {
     if (positionX == null || positionX < 0) {
         return
@@ -117,6 +122,15 @@ internal fun OverlayInformation(
                 }
             )
     ) {
-        content()
+        /*
+            Providing the xIsCloseToCenter Boolean to content is necessary for cases when the overlay content
+            is wide and does not fit on the screen only when the cursor is in the middle of the X-axis.
+            With the help of this Boolean parameter the user can alter the width of the content
+            when needed.
+        */
+        val halfContainerWidth = containerSize.width / 2
+        val oneTenth = containerSize.width / 10
+        val xIsCloseToCenter = positionX in (halfContainerWidth-oneTenth)..(halfContainerWidth+oneTenth)
+        content(xIsCloseToCenter)
     }
 }

--- a/charts/src/commonMain/kotlin/com/netguru/multiplatform/charts/bar/BarChart.kt
+++ b/charts/src/commonMain/kotlin/com/netguru/multiplatform/charts/bar/BarChart.kt
@@ -61,7 +61,7 @@ fun BarChart(
     yAxisMarkerLayout: @Composable (value: Any) -> Unit = GridDefaults.YAxisMarkerLayout,
     yAxisLabelLayout: (@Composable () -> Unit)? = GridDefaults.YAxisDataTitleLayout,
     animation: ChartAnimation = ChartAnimation.Simple(),
-    overlayDataEntryLabel: @Composable (dataName: String, dataNameShort: String?, dataUnit: String?, value: Any) -> Unit = GridDefaults.OverlayDataEntryLabel,
+    overlayDataEntryLabel: @Composable (dataName: String, dataNameShort: String?, dataUnit: String?, value: Any, xIsCloseToCenter: Boolean?) -> Unit = GridDefaults.OverlayDataEntryLabel,
 ) {
     val verticalLinesCount = remember(data) { data.maxX.toInt() + 1 }
 
@@ -197,7 +197,7 @@ private fun BoxWithConstraintsScope.SelectedValueLabel(
     position: PointF,
     data: BarChartBar,
     colors: BarChartColors,
-    overlayDataEntryLabel: @Composable (dataName: String, dataNameShort: String?, dataUnit: String?, value: Any) -> Unit
+    overlayDataEntryLabel: @Composable (dataName: String, dataNameShort: String?, dataUnit: String?, value: Any, xIsCloseToCenter: Boolean?) -> Unit
 ) {
     OverlayInformation(
         positionX = position.x,
@@ -211,7 +211,7 @@ private fun BoxWithConstraintsScope.SelectedValueLabel(
         touchOffsetVertical = LocalDensity.current.run { position.y!!.toDp() },
         touchOffsetHorizontal = 20.dp,
         content = {
-            overlayDataEntryLabel(data.data.x, null, null, data.data.y)
+            overlayDataEntryLabel(data.data.x, null, null, data.data.y, null)
         },
         requiredOverlayWidth = 200.dp,
         overlayAlpha = 0.9f,

--- a/charts/src/commonMain/kotlin/com/netguru/multiplatform/charts/grid/GridDefaults.kt
+++ b/charts/src/commonMain/kotlin/com/netguru/multiplatform/charts/grid/GridDefaults.kt
@@ -52,8 +52,8 @@ internal object GridDefaults {
         )
     }
 
-    val OverlayDataEntryLabel: @Composable (dataName: String, dataNameShort: String?, dataUnit: String?, value: Any) -> Unit =
-        { dataName, dataNameShort, dataUnit, value ->
+    val OverlayDataEntryLabel: @Composable (dataName: String, dataNameShort: String?, dataUnit: String?, value: Any, xIsCloseToCenter: Boolean?) -> Unit =
+        { dataName, dataNameShort, dataUnit, value, _ ->
             Text(
                 text = "$dataName${dataNameShort?.let { " ($it)" }.orEmpty()}: $value" + dataUnit?.let { " $it" }
                     .orEmpty()

--- a/charts/src/commonMain/kotlin/com/netguru/multiplatform/charts/line/LineChartOverlayInformation.kt
+++ b/charts/src/commonMain/kotlin/com/netguru/multiplatform/charts/line/LineChartOverlayInformation.kt
@@ -82,7 +82,7 @@ private fun LineChartOverlayInformation(
     containerSize: Size,
     colors: LineChartColors,
     overlayHeaderLayout: @Composable (value: Any, dataUnit: String?) -> Unit,
-    overlayDataEntryLayout: @Composable (dataName: String, dataNameShort: String?, dataUnit: String?, value: Any) -> Unit,
+    overlayDataEntryLayout: @Composable (dataName: String, dataNameShort: String?, dataUnit: String?, value: Any, xIsCloseToCenter: Boolean?) -> Unit,
     drawPoints: (points: List<SeriesAndClosestPoint>) -> Unit,
     highlightPointsCloserThan: Dp,
     touchOffsetHorizontal: Dp,
@@ -153,7 +153,7 @@ private fun LineChartOverlayInformation(
             touchOffsetVertical = touchOffsetVertical,
             requiredOverlayWidth = overlayWidth,
             overlayAlpha = overlayAlpha,
-        ) {
+        ) { xIsCloseToCenter ->
             Column(
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.spacedBy(8.dp),
@@ -195,7 +195,7 @@ private fun LineChartOverlayInformation(
                                         val dataNameShort = seriesAndClosestPoint.lineChartSeries.dataNameShort
                                         val dataUnit = seriesAndClosestPoint.dataUnit
                                         val value = seriesAndClosestPoint.closestPoint.y
-                                        overlayDataEntryLayout(dataName, dataNameShort, dataUnit, value!!)
+                                        overlayDataEntryLayout(dataName, dataNameShort, dataUnit, value!!, xIsCloseToCenter)
                                     }
                                 }
                         }
@@ -226,7 +226,7 @@ private fun LineChartOverlayInformationWithInterpolatedValues(
     containerSize: Size,
     colors: LineChartColors,
     overlayHeaderLayout: @Composable (value: Any, dataUnit: String?) -> Unit,
-    overlayDataEntryLayout: @Composable (dataName: String, dataNameShort: String?, dataUnit: String?, value: Any) -> Unit,
+    overlayDataEntryLayout: @Composable (dataName: String, dataNameShort: String?, dataUnit: String?, value: Any, xIsCloseToCenter: Boolean?) -> Unit,
     touchOffsetHorizontal: Dp,
     touchOffsetVertical: Dp,
     overlayWidth: Dp?,
@@ -261,7 +261,7 @@ private fun LineChartOverlayInformationWithInterpolatedValues(
             touchOffsetVertical = touchOffsetVertical,
             requiredOverlayWidth = overlayWidth,
             overlayAlpha = overlayAlpha,
-            content = {
+            content = { xIsCloseToCenter ->
                 Column(
                     horizontalAlignment = Alignment.CenterHorizontally,
                 ) {
@@ -295,7 +295,7 @@ private fun LineChartOverlayInformationWithInterpolatedValues(
 
                             val dataName = seriesAndInterpolatedValue.lineChartSeries.dataName
                             val interpolatedValue = seriesAndInterpolatedValue.interpolatedValue
-                            overlayDataEntryLayout(dataName, dataNameShort, dataUnit, interpolatedValue)
+                            overlayDataEntryLayout(dataName, dataNameShort, dataUnit, interpolatedValue, xIsCloseToCenter)
                         }
                     }
                 }

--- a/charts/src/commonMain/kotlin/com/netguru/multiplatform/charts/line/LineChartWithTwoYAxisSets.kt
+++ b/charts/src/commonMain/kotlin/com/netguru/multiplatform/charts/line/LineChartWithTwoYAxisSets.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import com.netguru.multiplatform.charts.ChartAnimation
 import com.netguru.multiplatform.charts.getAnimationAlphas
 import com.netguru.multiplatform.charts.grid.*
@@ -350,6 +351,7 @@ private fun LineChartWithTwoYAxisSetsLayout(
                     yAxisTitleData = rightYAxisData.yAxisTitleData,
                     modifier = Modifier
                         .padding(start = 8.dp)
+                        .zIndex(-1f)
                 )
             }
         }

--- a/charts/src/commonMain/kotlin/com/netguru/multiplatform/charts/line/OverlayData.kt
+++ b/charts/src/commonMain/kotlin/com/netguru/multiplatform/charts/line/OverlayData.kt
@@ -7,7 +7,7 @@ import com.netguru.multiplatform.charts.grid.GridDefaults
 
 data class OverlayData(
     val overlayHeaderLabel: @Composable (value: Any, dataUnit: String?) -> Unit = GridDefaults.OverlayHeaderLabel,
-    val overlayDataEntryLabel: @Composable (dataName: String, dataNameShort: String?, dataUnit: String?, value: Any) -> Unit = GridDefaults.OverlayDataEntryLabel,
+    val overlayDataEntryLabel: @Composable (dataName: String, dataNameShort: String?, dataUnit: String?, value: Any, xIsCloseToCenter: Boolean?) -> Unit = GridDefaults.OverlayDataEntryLabel,
     val showEnlargedPointOnLine: Boolean = false,
     val showInterpolatedValues: Boolean = true,
     val highlightPointsCloserThan: Dp = 30.dp,

--- a/example-app/android/src/main/java/com/netguru/multiplatform/charts/android/previews/BarChartPreview.kt
+++ b/example-app/android/src/main/java/com/netguru/multiplatform/charts/android/previews/BarChartPreview.kt
@@ -82,5 +82,6 @@ fun barChartSampleData(): BarChartData {
                 )
             ),
         ),
+        unit = null
     )
 }

--- a/example-app/android/src/main/java/com/netguru/multiplatform/charts/android/previews/LineChartPreview.kt
+++ b/example-app/android/src/main/java/com/netguru/multiplatform/charts/android/previews/LineChartPreview.kt
@@ -43,7 +43,7 @@ private fun getLineChartSampleData(): LineChartData {
         LineChartSeries(
             "Solar",
             lineColor = AppTheme.colors.yellow,
-            dashedLine = false,
+            //dashedLine = false,
             listOfPoints = listOf(
                 LineChartPoint(0L * HOUR_IN_MS + startTime, 0f),
                 LineChartPoint(1L * HOUR_IN_MS + startTime, 1f),
@@ -58,7 +58,7 @@ private fun getLineChartSampleData(): LineChartData {
         LineChartSeries(
             "Grid",
             lineColor = AppTheme.colors.green,
-            dashedLine = false,
+            //dashedLine = false,
             listOfPoints = listOf(
                 LineChartPoint(0L * HOUR_IN_MS + startTime, 3f),
                 LineChartPoint(1L * HOUR_IN_MS + startTime, 2f),
@@ -72,7 +72,7 @@ private fun getLineChartSampleData(): LineChartData {
         LineChartSeries(
             "Fossil",
             lineColor = AppTheme.colors.blue,
-            dashedLine = false,
+            //dashedLine = false,
             listOfPoints = listOf(
                 LineChartPoint(0L * HOUR_IN_MS + startTime, 1f),
                 LineChartPoint(1L * HOUR_IN_MS + startTime, 3f),
@@ -85,5 +85,6 @@ private fun getLineChartSampleData(): LineChartData {
 
     return LineChartData(
         series = list,
+        dataUnit = null
     )
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 ## SDK Versions
-compileSdk = "31"
+compileSdk = "33"
 minSdk = "24"
 targetSdk = "31"
 versionCode = "1"


### PR DESCRIPTION
### Task
<!-- Add links to JIRA task and other relevant resources -->
- [Keto-Mojo JIRA](https://keto-mojo.atlassian.net/browse/MSA-768)

### Description
- Bumped `compileSdk` and edited previews
- Added low `zIndex` to right `YAxisLabels` in `LineChartWithTwoYAxisSets` so that they do not get drawn above `LineChartTooltip`
- Added the `xIsCloseToCenter: Boolean?` parameter to `OverlayData`'s `val overlayDataEntryLabel`. Implemented usage of the modified `OverlayData` wherever needed.